### PR TITLE
refactor: Store user ID in request context

### DIFF
--- a/cmd/recipes/auth.go
+++ b/cmd/recipes/auth.go
@@ -1,0 +1,53 @@
+package main
+
+import "net/http"
+
+const sessionKeyUserID = "authenticatedUserID"
+
+// isAuthenticated returns a boolean indicating if the request session is for an authenticated user.
+func isAuthenticated(r *http.Request) bool {
+	userID, ok := r.Context().Value(contextKeyUserID).(string)
+	if !ok {
+		return false
+	}
+
+	return userID != ""
+}
+
+// reqUser returns the ID of the user who made the request. The user is guaranteed to have existed
+// when the request was received. This function only works if passed through `app.authenticate`
+// first.
+func reqUser(r *http.Request) string {
+	userID, ok := r.Context().Value(contextKeyUserID).(string)
+	if !ok {
+		return ""
+	}
+
+	return userID
+}
+
+// setAuthenticatedUser stores the provided user ID in the session associated with the request as
+// the currently authenticated user.
+func (app *application) setAuthenticatedUser(r *http.Request, id string) error {
+	// Renew the session token to prevent session fixation attacks.
+	if err := app.sessionManager.RenewToken(r.Context()); err != nil {
+		return err
+	}
+
+	app.sessionManager.Put(r.Context(), sessionKeyUserID, id)
+
+	return nil
+}
+
+// clearAuthenticatedUser removes the currently authenticated user's ID from the session so that
+// future requests will be unauthenticated.
+func (app *application) clearAuthenticatedUser(r *http.Request) error {
+	// Renew the session token to prevent session fixation attacks.
+	if err := app.sessionManager.RenewToken(r.Context()); err != nil {
+		return err
+	}
+
+	app.sessionManager.Remove(r.Context(), sessionKeyUserID)
+
+	return nil
+}

--- a/cmd/recipes/context.go
+++ b/cmd/recipes/context.go
@@ -2,4 +2,4 @@ package main
 
 type contextKey string
 
-const isAuthenticatedContextKey = contextKey("isAuthenticated")
+const contextKeyUserID = contextKey("userID")

--- a/cmd/recipes/helpers.go
+++ b/cmd/recipes/helpers.go
@@ -45,13 +45,3 @@ func (app *application) render(w http.ResponseWriter, r *http.Request, status in
 	w.WriteHeader(status)
 	buf.WriteTo(w)
 }
-
-// isAuthenticated returns a boolean indicating if the request session is for an authenticated user.
-func (app *application) isAuthenticated(r *http.Request) bool {
-	isAuthenticated, ok := r.Context().Value(isAuthenticatedContextKey).(bool)
-	if !ok {
-		return false
-	}
-
-	return isAuthenticated
-}

--- a/cmd/recipes/templates.go
+++ b/cmd/recipes/templates.go
@@ -24,6 +24,6 @@ type templateData struct {
 func (app *application) newTemplateData(r *http.Request) templateData {
 	return templateData{
 		CSRFToken:       nosurf.Token(r),
-		IsAuthenticated: app.isAuthenticated(r),
+		IsAuthenticated: isAuthenticated(r),
 	}
 }


### PR DESCRIPTION
Refactored the authentication process to store the user ID in the request context. This means that we don't couple each handler to the session just for user IDs.
