### PR TITLE
Add unique tracing ID to requests

### DIFF
--- a/cmd/recipes/application.go
+++ b/cmd/recipes/application.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cdriehuys/recipes/internal/models"
 	"github.com/cdriehuys/recipes/internal/staticfiles"
 	"github.com/cdriehuys/recipes/internal/templates"
+	"github.com/cdriehuys/recipes/internal/tracing"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -85,7 +86,10 @@ func newApplication(
 	staticFS fs.FS,
 	templateFS fs.FS,
 ) (*application, error) {
-	logger := slog.New(slog.NewTextHandler(logStream, nil))
+	handler := tracing.Handler{
+		Handler: slog.NewTextHandler(logStream, nil),
+	}
+	logger := slog.New(handler)
 
 	oauthConfig := oauth2.Config{
 		ClientID:     config.GoogleClientID,

--- a/cmd/recipes/helpers.go
+++ b/cmd/recipes/helpers.go
@@ -15,7 +15,7 @@ func (app *application) serverError(w http.ResponseWriter, r *http.Request, err 
 		uri    = r.URL.RequestURI()
 	)
 
-	app.logger.Error(err.Error(), "method", method, "uri", uri)
+	app.logger.ErrorContext(r.Context(), err.Error(), "method", method, "uri", uri)
 
 	if app.config.DevMode {
 		trace := debug.Stack()

--- a/cmd/recipes/recipe_handlers.go
+++ b/cmd/recipes/recipe_handlers.go
@@ -50,7 +50,7 @@ func (app *application) addRecipePost(w http.ResponseWriter, r *http.Request) {
 	form.Validate()
 
 	if !form.IsValid() {
-		app.logger.Debug("New recipe form did not validate.")
+		app.logger.DebugContext(r.Context(), "New recipe form did not validate.")
 
 		categories, err := app.categoryModel.List(r.Context(), userID)
 		if err != nil {

--- a/cmd/recipes/routes.go
+++ b/cmd/recipes/routes.go
@@ -3,13 +3,14 @@ package main
 import (
 	"net/http"
 
+	"github.com/cdriehuys/recipes/internal/tracing"
 	"github.com/justinas/alice"
 )
 
 func (app *application) routes() http.Handler {
 	mux := http.NewServeMux()
 
-	standard := alice.New(app.recoverPanic, app.requestLogger)
+	standard := alice.New(app.recoverPanic, tracing.AddTrace, app.requestLogger)
 
 	mux.Handle(
 		"/static/",

--- a/internal/models/categories.go
+++ b/internal/models/categories.go
@@ -53,7 +53,7 @@ func (model *CategoryModel) List(ctx context.Context, owner string) ([]Category,
 		return nil, fmt.Errorf("failed to map category rows to struct: %w", err)
 	}
 
-	model.Logger.Debug("Retrieved category list from database.", "categories", categories)
+	model.Logger.DebugContext(ctx, "Retrieved category list from database.", "categories", categories)
 
 	return categories, nil
 }

--- a/internal/models/recipes.go
+++ b/internal/models/recipes.go
@@ -60,7 +60,7 @@ VALUES ($1, $2, $3, $4, $5)`
 		return fmt.Errorf("failed to insert new recipe: %w", err)
 	}
 
-	model.Logger.Info("Persisted new recipe.", "id", recipe.ID)
+	model.Logger.InfoContext(ctx, "Persisted new recipe.", "id", recipe.ID)
 
 	return nil
 }
@@ -72,7 +72,7 @@ func (model *RecipeModel) Delete(ctx context.Context, owner string, id uuid.UUID
 		return fmt.Errorf("failed to delete recipe with ID %v: %w", id, err)
 	}
 
-	model.Logger.Info("Deleted recipe.", "id", id)
+	model.Logger.InfoContext(ctx, "Deleted recipe.", "id", id)
 
 	return nil
 }
@@ -116,7 +116,7 @@ func (model *RecipeModel) List(ctx context.Context, owner string) ([]Recipe, err
 		return nil, fmt.Errorf("failed to map recipe rows to struct: %w", err)
 	}
 
-	model.Logger.Debug("Retrieved recipe list from database.", "recipes", recipes)
+	model.Logger.DebugContext(ctx, "Retrieved recipe list from database.", "recipes", recipes)
 
 	return recipes, nil
 }

--- a/internal/models/users.go
+++ b/internal/models/users.go
@@ -59,7 +59,7 @@ func (model *UserModel) UpdateName(ctx context.Context, id, name string) error {
 		return fmt.Errorf("failed to update user details: %w", err)
 	}
 
-	model.Logger.Info("Updated user details.", "id", id)
+	model.Logger.InfoContext(ctx, "Updated user details.", "id", id)
 
 	return nil
 }

--- a/internal/templates/disk.go
+++ b/internal/templates/disk.go
@@ -19,7 +19,7 @@ type DiskTemplateEngine struct {
 	Logger *slog.Logger
 }
 
-func (e *DiskTemplateEngine) Write(w io.Writer, _ *http.Request, name string, data any) error {
+func (e *DiskTemplateEngine) Write(w io.Writer, r *http.Request, name string, data any) error {
 	includes, err := filepath.Glob(path.Join(e.IncludePath, "*.html.tmpl"))
 	if err != nil {
 		return fmt.Errorf("could not find includes: %w", err)
@@ -27,7 +27,7 @@ func (e *DiskTemplateEngine) Write(w io.Writer, _ *http.Request, name string, da
 
 	templatePath := path.Join(e.LayoutPath, name+".html.tmpl")
 	templateFiles := append(includes, templatePath)
-	e.Logger.Debug("Collected template files.", "templateFiles", templateFiles)
+	e.Logger.DebugContext(r.Context(), "Collected template files.", "templateFiles", templateFiles)
 
 	tpl := template.New(name).Funcs(e.FuncMap)
 

--- a/internal/tracing/logging.go
+++ b/internal/tracing/logging.go
@@ -1,0 +1,18 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+)
+
+type Handler struct {
+	slog.Handler
+}
+
+func (h Handler) Handle(ctx context.Context, r slog.Record) error {
+	if traceID, ok := ctx.Value(traceCtxKey).(string); ok {
+		r.Add("trace_id", traceID)
+	}
+
+	return h.Handler.Handle(ctx, r)
+}

--- a/internal/tracing/middleware.go
+++ b/internal/tracing/middleware.go
@@ -1,0 +1,24 @@
+package tracing
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const traceCtxKey = contextKey("recipes.trace")
+
+// AddTrace adds a unique tracing ID to the request's context before passing it to the next handler.
+func AddTrace(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		traceID := uuid.New().String()
+		ctx := context.WithValue(r.Context(), traceCtxKey, traceID)
+
+		tracedRequest := r.WithContext(ctx)
+
+		next.ServeHTTP(w, tracedRequest)
+	})
+}

--- a/internal/tracing/middleware_test.go
+++ b/internal/tracing/middleware_test.go
@@ -1,0 +1,27 @@
+package tracing
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func Test_AddTrace(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		traceID, ok := r.Context().Value(traceCtxKey).(string)
+		if !ok {
+			t.Error("Expected request to have tracing ID")
+		}
+
+		if traceID == "" {
+			t.Error("Expected trace ID to be non-empty")
+		}
+	}
+
+	decorated := AddTrace(http.HandlerFunc(handler))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	decorated.ServeHTTP(w, r)
+}


### PR DESCRIPTION
Generate a unique ID for each request that is propagated within the request's context. This allows logging messages to be associated with a specific request as long as the context is passed to the logger.
